### PR TITLE
Feature/responsive map

### DIFF
--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -1,3 +1,4 @@
+import { BASE_SCREEN_SIZE, getOptimalScale } from 'components/map/map-helper'
 import React, { useRef, useEffect } from 'react'
 
 export type CanvasProps = {
@@ -5,20 +6,14 @@ export type CanvasProps = {
     onWheel: (ctx: CanvasRenderingContext2D, e: WheelEvent) => void
     onMouseMove: (ctx: CanvasRenderingContext2D, e: MouseEvent) => void
     onClick: (ctx: CanvasRenderingContext2D, e: MouseEvent) => void
-    attributes?: React.CanvasHTMLAttributes<HTMLCanvasElement>
+    attributes: React.CanvasHTMLAttributes<HTMLCanvasElement>
 }
 
-const Canvas = ({
-    drawOnCanvas,
-    onWheel,
-    onMouseMove,
-    onClick,
-    attributes
-}: CanvasProps) => {
+const Canvas = ({ drawOnCanvas, onWheel, onMouseMove, onClick, attributes: { width, height } }: CanvasProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null)
 
     useEffect(() => {
-        if (!canvasRef.current) return
+        if (!canvasRef.current || !width) return
 
         const canvas = canvasRef.current
         const context = canvas.getContext('2d')
@@ -26,6 +21,13 @@ const Canvas = ({
         if (!context) return
 
         let animationFrameId: number
+
+        const currentScale = context.getTransform().a
+        const scale = getOptimalScale(Number(width))
+
+        if (BASE_SCREEN_SIZE >= width && currentScale > scale) {
+            context.scale(scale, scale)
+        }
 
         const render = () => {
             drawOnCanvas(context)
@@ -36,8 +38,7 @@ const Canvas = ({
         return () => {
             cancelAnimationFrame(animationFrameId)
         }
-
-    }, [drawOnCanvas])
+    }, [drawOnCanvas, width])
 
     useEffect(() => {
         if (!canvasRef.current) return
@@ -62,7 +63,7 @@ const Canvas = ({
         }
     }, [onClick, onMouseMove, onWheel])
 
-    return <canvas ref={canvasRef} {...attributes} />
+    return <canvas ref={canvasRef} {...{ width, height }} />
 }
 
 export default Canvas

--- a/components/map/index.module.scss
+++ b/components/map/index.module.scss
@@ -1,5 +1,5 @@
-@import 'styles/colors.scss';
+@import 'styles/screens.scss';
 
 :export {
-    backgroundColor: $color-mine-shaft;
+    screenMedium: $screen-medium;
 }

--- a/components/map/index.tsx
+++ b/components/map/index.tsx
@@ -4,10 +4,12 @@ import { endpoints } from 'utils/api-config'
 import {
     convertToMapPlot,
     drawGrid,
+    getOptimalScale,
     getSppPlot,
     getStartPosition,
     GRID_SIZE,
-    MAGIC_NUMBER_TO_ADJUST
+    MAGIC_NUMBER_TO_ADJUST,
+    ORIGINAL_MAP_WIDTH
 } from './map-helper'
 import Plot from './plots/plot'
 
@@ -19,7 +21,7 @@ export type MapProps = {
 }
 
 // TO LOCK THE SIZE OF THE MAP TO 1x
-// const DEFAULT_MAP_SCALE = 1
+const DEFAULT_MAP_SCALE = 1
 // const ZOOM_SENSITIVITY = 0.0001
 // const MAX_SCALE = 2
 // const MIN_SCALE = 0.8
@@ -31,6 +33,7 @@ const HORIZONTAL_SCROLL_SENSITIVITY = 0.05
 const Map = ({ width, height, headerHeight, onSelectPlot }: MapProps) => {
     const mouseRef = useRef({ x: -1, y: -1 })
     const startPositionRef = useRef({ x: -1, y: -1 })
+    const initialScaleRef = useRef(DEFAULT_MAP_SCALE)
     const [mapPlots, setMapPlots] = useState<MapPlotType[]>([])
 
     const renderPlotHover = (ctx: CanvasRenderingContext2D) => (x: number, y: number) => {
@@ -88,12 +91,18 @@ const Map = ({ width, height, headerHeight, onSelectPlot }: MapProps) => {
 
         const { x, y } = startPositionRef.current
 
-        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+        if (ORIGINAL_MAP_WIDTH * initialScaleRef.current > width) {
+            // if map width is bigger than canvas width, increase the range to be cleared
+            // otherwise the area initially not rendered on screen will not be cleared
+            // when scrolling horizontally
+            ctx.clearRect(-width, -height, (width / initialScaleRef.current) * 2, height * 2)
+        } else {
+            ctx.clearRect(0, 0, width, height)
+        }
 
         drawGrid(ctx, { x, y })
         renderPlots(ctx)(x, y)
     }
-
     // TO LOCK THE SIZE OF THE MAP TO 1x
     // const onScrollY = (ctx: CanvasRenderingContext2D, e: WheelEvent) => {
     //     const currentScale = ctx.getTransform().a
@@ -177,8 +186,10 @@ const Map = ({ width, height, headerHeight, onSelectPlot }: MapProps) => {
         if (width === undefined || height === undefined) return
 
         const { x, y } = getStartPosition(width, height)
-
         startPositionRef.current = { x, y }
+
+        const optimalScale = getOptimalScale(width)
+        initialScaleRef.current = optimalScale
     }, [width, height])
 
     return (

--- a/components/map/map-helper.ts
+++ b/components/map/map-helper.ts
@@ -7,6 +7,8 @@ export const MINIMUM_MAP_SCALE = 1 / 2 // half of the original size
 export const BASE_SCREEN_SIZE = Number(variables.screenMedium.replace('px', ''))
 
 export const GRID_SIZE = 10 // Math.sqrt of plotMap length (=100)
+export const ORIGINAL_MAP_WIDTH = Plot.PLOT_WIDTH * GRID_SIZE
+
 // TODO: FIGURE OUT HOW THIS IS DETERMINED
 export const MAGIC_NUMBER_TO_ADJUST = 80
 

--- a/components/map/map-helper.ts
+++ b/components/map/map-helper.ts
@@ -46,12 +46,15 @@ export const getOptimalScale = (canvasWidth: number) => {
 }
 
 export const getStartPosition = (canvasWidth: number, canvasHeight: number) => {
+    const halfCanvasWidth = canvasWidth / 2
+
     const offsetX = Plot.PLOT_WIDTH / 2
     const offsetY = Plot.PLOT_HEIGHT
 
     const remainingHeight = canvasHeight - Plot.PLOT_HEIGHT * GRID_SIZE
 
-    const x = canvasWidth / 2 - offsetX
+    const scale = getOptimalScale(canvasWidth)
+    const x = halfCanvasWidth / scale - offsetX
     // MAGIC_NUMBER_TO_ADJUST is to adjust position when calling plot.drawplot()
     const y = remainingHeight / 2 + offsetY - MAGIC_NUMBER_TO_ADJUST
 

--- a/components/map/map-helper.ts
+++ b/components/map/map-helper.ts
@@ -1,6 +1,10 @@
 import Plot, { Position2D } from './plots/plot'
 // TODO: should change image once design for SPP is ready
 import SPP from 'public/images/map-tile-strip-lake.png'
+import variables from './index.module.scss'
+
+export const MINIMUM_MAP_SCALE = 1 / 2 // half of the original size
+export const BASE_SCREEN_SIZE = Number(variables.screenMedium.replace('px', ''))
 
 export const GRID_SIZE = 10 // Math.sqrt of plotMap length (=100)
 // TODO: FIGURE OUT HOW THIS IS DETERMINED
@@ -35,6 +39,10 @@ export const convertToMapPlot = ({ offchainUrl, positionX, positionY, ...rest }:
         index: positionToIndex({ x: positionX, y: positionY }),
         image
     }
+}
+
+export const getOptimalScale = (canvasWidth: number) => {
+    return Math.max(Math.min(canvasWidth / BASE_SCREEN_SIZE, 1), MINIMUM_MAP_SCALE)
 }
 
 export const getStartPosition = (canvasWidth: number, canvasHeight: number) => {


### PR DESCRIPTION
- make the map size responsible

Note:
When the map size is smaller than scale 1 (default size) the tile hover effect does not work properly, which I think I told you when I implemented zoom function.
I will work on it when I implement zoom function for smartphones if it would be ok